### PR TITLE
Add limits to most tasks spotted, to avoid entering a failstate loop

### DIFF
--- a/src/tasks/familiarweight.ts
+++ b/src/tasks/familiarweight.ts
@@ -55,6 +55,7 @@ export const FamiliarWeightQuest: Quest = {
       do: (): void => {
         cliExecute("spoon platypus");
       },
+      limit: { tries: 1 },
     },
     {
       name: "Late Eat Deep Dish",
@@ -78,6 +79,7 @@ export const FamiliarWeightQuest: Quest = {
         shrugAT();
         cliExecute("cast 1 Chorale of Companionship");
       },
+      limit: { tries: 1 },
     },
     {
       name: "Fold Burning Newspaper",

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -396,11 +396,13 @@ export const LevelingQuest: Quest = {
       ready: () => have($item`candy cane sword cane`),
       completed: () => get("_lyleFavored"),
       do: () => cliExecute("monorail buff"),
+      limit: { tries: 1 },
     },
     {
       name: "Telescope",
       completed: () => get("telescopeLookedHigh"),
       do: () => cliExecute("telescope look high"),
+      limit: { tries: 1 },
     },
     {
       name: "Offhand Remarkable Maybe",
@@ -430,6 +432,7 @@ export const LevelingQuest: Quest = {
       do: (): void => {
         while (mySoulsauce() >= 5 && myMp() <= myMaxmp() - 15) useSkill($skill`Soul Food`);
       },
+      limit: { tries: 50 },
     },
     {
       name: "Clan Shower",
@@ -619,6 +622,7 @@ export const LevelingQuest: Quest = {
         }
       },
       outfit: { modifier: "myst, mp, -tie" },
+      limit: { tries: 50 },
     },
     {
       name: "Alice Army",
@@ -693,6 +697,7 @@ export const LevelingQuest: Quest = {
       },
       completed: () => have(generalStoreXpEffect),
       do: () => ensureEffect(generalStoreXpEffect),
+      limit: { tries: 1 },
     },
     {
       name: "Buy Oversized Sparkler",
@@ -954,6 +959,7 @@ export const LevelingQuest: Quest = {
         ...baseOutfit(true, false, $monster`ice woman`),
         back: $item`protonic accelerator pack`,
       }),
+      limit: { tries: 3 },
     },
     {
       name: "Map Amateur Ninja",
@@ -1177,6 +1183,7 @@ export const LevelingQuest: Quest = {
         }
         use(1, $item`Dramatic™ range`);
       },
+      limit: { tries: 1 },
     },
     {
       name: "Use Reagent Booster",
@@ -1190,6 +1197,7 @@ export const LevelingQuest: Quest = {
         }
         ensureEffect(reagentBoosterEffect);
       },
+      limit: { tries: 5 },
     },
     {
       name: "Use Reagent Balancer",
@@ -1412,6 +1420,7 @@ export const LevelingQuest: Quest = {
         }
       },
       outfit: { modifier: "myst, mp" },
+      limit: { tries: 10 },
     },
     {
       name: "Kramco",
@@ -1430,6 +1439,7 @@ export const LevelingQuest: Quest = {
         sellMiscellaneousItems();
         boomBoxProfit();
       },
+      limit: { tries: 10 },
     },
     {
       name: "Oliver's Place (Peridot)",

--- a/src/tasks/runstart.ts
+++ b/src/tasks/runstart.ts
@@ -85,6 +85,7 @@ export const RunStartQuest: Quest = {
       name: "Council",
       completed: () => get("lastCouncilVisit") > 0,
       do: () => visitUrl("council.php"),
+      limit: { tries: 1 },
     },
     {
       name: "Apriling Part 1",
@@ -157,18 +158,20 @@ export const RunStartQuest: Quest = {
         1494: bestSIT,
       },
       do: () => use($item`S.I.T. Course Completion Certificate`),
+      limit: { tries: 1 },
     },
     {
       name: "Do Pullls",
       completed: () => 5 - get("_roninStoragePulls").split(",").length <= args.savepulls,
       do: () => {
-        buyUsingStorage($item`tobiko marble soda`, 1);
+        if (storageAmount($item`tobiko marble soda`) === 0) buyUsingStorage($item`tobiko marble soda`, 1);
         takeStorage($item`Great Wolf's beastly trousers`, 1);
         takeStorage($item`meteorite necklace`, 1);
         takeStorage($item`Stick-Knife of Loathing`, 1);
         takeStorage($item`Staff of Simmering Hatred`, 1);
         takeStorage($item`tobiko marble soda`, 1);
       },
+      limit: { tries: 1 },
     },
     {
       name: "Tune Cape",
@@ -178,6 +181,7 @@ export const RunStartQuest: Quest = {
         cliExecute(`retrocape ${optimalCape}`);
         capeTuned = true;
       },
+      limit: { tries: 1 },
     },
     {
       name: "Get Floundry item",
@@ -216,6 +220,7 @@ export const RunStartQuest: Quest = {
         }
       },
       outfit: { modifier: "myst, mp, -tie" },
+      limit: { tries: 25 },
     },
     {
       name: "Numberology",
@@ -313,6 +318,7 @@ export const RunStartQuest: Quest = {
         visitUrl("place.php?whichplace=town_right&action=townright_vote");
         goVote();
       },
+      limit: { tries: 1 },
     },
     {
       name: "Daycare Nap",
@@ -352,11 +358,13 @@ export const RunStartQuest: Quest = {
         cliExecute("backupcamera ml");
         if (!get("backupCameraReverserEnabled")) cliExecute("backupcamera reverser");
       },
+      limit: { tries: 1 },
     },
     {
       name: "Update Garbage Tote",
       completed: () => get("_garbageItemChanged") || !have($item`January's Garbage Tote`),
       do: () => cliExecute("fold broken champagne bottle"),
+      limit: { tries: 1 },
     },
     {
       name: "Grab Wishes",
@@ -419,6 +427,7 @@ export const RunStartQuest: Quest = {
           use($item`Asdon Martin keyfob (on ring)`);
         } else use($item`model train set`);
       },
+      limit: { tries: 1 },
     },
     {
       name: "Soul Food",
@@ -427,6 +436,7 @@ export const RunStartQuest: Quest = {
       do: (): void => {
         while (mySoulsauce() >= 5 && myMp() <= myMaxmp() - 15) useSkill($skill`Soul Food`);
       },
+      limit: { tries: 10 },
     },
     {
       name: "Use Mind Control Device",
@@ -486,6 +496,7 @@ export const RunStartQuest: Quest = {
         visitUrl("inventory.php?action=skiduffel&pwd");
         duffo = true;
       },
+      limit: { tries: 1 },
     },
     {
       name: "Borrowed Time",
@@ -607,6 +618,7 @@ export const RunStartQuest: Quest = {
         back: $item`protonic accelerator pack`,
         avoid: $items`Daylight Shavings Helmet`,
       }),
+      limit: { tries: 3 },
     },
     {
       name: "Kramco",
@@ -629,6 +641,7 @@ export const RunStartQuest: Quest = {
         Macro.trySkill($skill`Launch spikolodon spikes`).default()
       ),
       post: () => set("_mobiusSeeded", true),
+      limit: { tries: 10 },
     },
     {
       name: "NEP The Prequel",
@@ -641,6 +654,7 @@ export const RunStartQuest: Quest = {
         offhand: $item`Kramco Sausage-o-Matic™`,
       }),
       combat: new CombatStrategy().macro(Macro.default()),
+      limit: { tries: 1 },
     },
     {
       name: "Pizza over Borrowed Time",

--- a/src/tasks/spelldamage.ts
+++ b/src/tasks/spelldamage.ts
@@ -81,6 +81,7 @@ export const SpellDamageQuest: Quest = {
         shrugAT();
         cliExecute("cast 1 Elron's Explosive Etude");
       },
+      limit: { tries: 1 },
     },
     {
       name: "Cargo Shorts",


### PR DESCRIPTION
Some of these limits could be wrong, especially concerning the rests or other areas. I'm unfamiliar with the considerations here, and I'm overthinking this too much.

Regardless, it seems like on my very first run of this, a pull failed to save itself to my prefs (http error?), and the pull task was being repeated, which purchased an item on every loop. I noticed after a few minutes so it wasn't too bad.